### PR TITLE
Added register/remove event to RuntimeConsole

### DIFF
--- a/Prefabs/ConsoleWindow.prefab
+++ b/Prefabs/ConsoleWindow.prefab
@@ -670,7 +670,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 2837657757107351180}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 7896174972223120371}
+        m_TargetAssemblyTypeName: TOMICZ.Debugger.ConsoleWindow, RuntimeConsole.Runtime
+        m_MethodName: RunEvent
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &8848398621795526129
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1039,7 +1051,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 48, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6006182736874484610
 CanvasRenderer:
@@ -1461,7 +1473,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: -0.000030517578}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 40}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &3347093467010206449
@@ -2718,7 +2730,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 48, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6002573488447879506
 CanvasRenderer:
@@ -3016,7 +3028,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 48, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4177608977379839737
 CanvasRenderer:
@@ -3829,7 +3841,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 7896174972660045901}
   m_HandleRect: {fileID: 7896174972660045902}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -4585,7 +4597,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 48, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7896174972677923184
 CanvasRenderer:
@@ -5099,7 +5111,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 4, y: 0.000015258789}
+  m_AnchoredPosition: {x: 4, y: -0.000061035156}
   m_SizeDelta: {x: -4, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &7896174973242335120
@@ -5346,7 +5358,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 48, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4103954932092817441
 CanvasRenderer:

--- a/Runtime/ConsoleWindow.cs
+++ b/Runtime/ConsoleWindow.cs
@@ -132,10 +132,9 @@ namespace TOMICZ.Debugger
 
         public void EnableConsole() => gameObject.SetActive(_isEnabled = !_isEnabled);
 
-        public void SelectInputField()
-        {
-            _commandInputField.Select();
-        }
+        public void SelectInputField() => _commandInputField.Select();
+
+        public void RunEvent() => RuntimeConsole.OnUnityRunEvent?.Invoke();
 
         private void RegisterHeaderEvents()
         {

--- a/Runtime/RuntimeConsole.cs
+++ b/Runtime/RuntimeConsole.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -5,11 +6,12 @@ namespace TOMICZ.Debugger
 {
     public static class RuntimeConsole
     {
-        private static ConsoleWindow _consoleWindow;
+        public static Action OnUnityRunEvent;
 
         public static List<WindowElement> WindowElementList = new List<WindowElement>();
 
         private static RuntimeCommands _runtimeCommands;
+        private static ConsoleWindow _consoleWindow;
 
         public static void SetupConsoleWindow(ConsoleWindow consoleWindow)
         {
@@ -17,10 +19,7 @@ namespace TOMICZ.Debugger
             _runtimeCommands = new RuntimeCommands();
         }
 
-        public static void AddWindowElement(WindowElement windowElement)
-        {
-            WindowElementList.Add(windowElement);
-        }
+        public static void AddWindowElement(WindowElement windowElement) => WindowElementList.Add(windowElement);
 
         public static void Log(string message) => LogWriter.LogMessage(LogMessage.GetType(LogMessageType.Log) + message);
 
@@ -43,15 +42,13 @@ namespace TOMICZ.Debugger
             }
         }
 
-        public static void PrintList(List<object> list)
-        {
-            _runtimeCommands.PrintList(list);
-        }
+        public static void PrintList(List<object> list) => _runtimeCommands.PrintList(list);
 
-        public static void PrintList(List<object> list, bool isSerialized)
-        {
-            _runtimeCommands.PrintList(list, isSerialized);
-        }
+        public static void PrintList(List<object> list, bool isSerialized) => _runtimeCommands.PrintList(list, isSerialized);
+
+        public static void RegisterEvent(Action action) => OnUnityRunEvent += action;
+
+        public static void RemoveEvent(Action action) => OnUnityRunEvent -= action;
 
         /// <summary>
         /// Checks if Console Window is available. If not, throws a warning to add it. 


### PR DESCRIPTION
A completely new feature with its dedicated Run button in ConsoleWindow. Enables developer to register any method as an event then then call them with Run button in ConsoleWindow.No more required to create a new button in the scene then attach a method to it then run it or doing if(Input.GetKeyDown(button) to test methods. Just register a method by calling RuntimeConsole.RegisterEvent(methodname) and then go to a console window and click run button.